### PR TITLE
update `sfbt/sam-johnson-playground-props`

### DIFF
--- a/src/yaml/sfbt/sam-johnson-playground-props.yaml
+++ b/src/yaml/sfbt/sam-johnson-playground-props.yaml
@@ -1,6 +1,6 @@
 group: sfbt
 name: sam-johnson-playground-props
-version: "0.1"
+version: "1"
 subfolder: 100-props-textures
 info:
   summary: Playground Props by Sam Johnson
@@ -17,6 +17,6 @@ assets:
 
 ---
 assetId: sfbt-sam-johnson-playground-props
-version: "0.1"
-lastModified: "2003-08-17T18:19:43.000Z"
+version: "1"
+lastModified: "2023-08-17T18:19:43Z"
 url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=122:sfbt-props-sam-johnson-playground-props


### PR DESCRIPTION
Update for `src/yaml/sfbt/sam-johnson-playground-props.yaml`:
```
Loaded report from /home/runner/work/_temp/api_reports/sc4e-report.json
sfbt-sam-johnson-playground-props:
  version: 0.1 -> version 1
  lastModified: 2003-08-17T18:19:43Z -> 2023-08-17T18:19:43Z
  Website: https://www.sc4evermore.com/index.php/downloads/download/122
  YAML: src/yaml/sfbt/sam-johnson-playground-props.yaml
There are 1 outdated SC4E assets, while 0 are up-to-date.
Updating src/yaml/sfbt/sam-johnson-playground-props.yaml ...
```
Website: https://www.sc4evermore.com/index.php/downloads/download/122